### PR TITLE
Add IDIR Authentication using LDAP

### DIFF
--- a/airflow/values.yaml
+++ b/airflow/values.yaml
@@ -1,6 +1,3 @@
-# Copyright VMware, Inc.
-# SPDX-License-Identifier: APACHE-2.0
-
 ## @section Global parameters
 ## Global Docker image parameters
 ## Please, note that this will override the image parameters, including dependencies, configured to use the global value
@@ -71,10 +68,10 @@ diagnosticMode:
 auth:
   ## @param auth.username Username to access web UI
   ##
-  username: datafoundationsteam # Abi: need to add users
+  username: amichel # Abi: can't use datafoundationsteam anymore because it needs to be a valid IDIR
   ## @param auth.password Password to access web UI
   ##
-  password: ${AIRFLOW_PASSWORD}
+  password: ""
 
   ## @param auth.fernetKey Fernet key to secure connections
   ## ref: https://airflow.readthedocs.io/en/stable/howto/secure-connections.html
@@ -1169,15 +1166,15 @@ git:
 ## @param ldap.rolesSyncAtLogin replace ALL the user's roles each login, or only on registration
 ##
 ldap:
-  enabled: false
-  uri: "ldap://ldap_server:389"
-  basedn: "dc=example,dc=org"
-  searchAttribute: "cn"
-  binddn: "cn=admin,dc=example,dc=org"
-  bindpw: ""
+  enabled: true # Abi: previously false
+  uri: 'ldap://idir.bcgov:389' # Abi: previously "ldap://ldap_server:389"
+  basedn: 'ou=BCGOV,dc=idir,dc=BCGOV' # Abi: previously "dc=example,dc=org"
+  searchAttribute: 'sAMAccountName' # Abi: previously "cn"
+  binddn: '${LDAP_SERVICE_ACCOUNT}@idir' # Abi: previously "cn=admin,dc=example,dc=org"
+  bindpw: '${LDAP_PASSWORD}'
   userRegistration: 'True'
-  userRegistrationRole: "Public"
-  rolesMapping: '{ "cn=All,ou=Groups,dc=example,dc=org": ["User"], "cn=Admins,ou=Groups,dc=example,dc=org": ["Admin"], }'
+  userRegistrationRole: 'Public'
+  rolesMapping: '{"cn=WLRS_DL_NRIDS_CSNRIMBARC,ou=Distribution Lists,ou=Exchange Objects,ou=Water Land and Resource Stewardship,ou=BCGOV,dc=idir,dc=BCGOV": ["User"], "*": ["Public"]}' # Abi: custom role mapping
   rolesSyncAtLogin: 'True'
 
   ## SSL/TLS parameters for LDAP


### PR DESCRIPTION
Story: As a product owner, I want Airflow access to be authenticated with IDIR while being able to assign roles and permissions. 

Documentation of Airflow security: https://airflow.apache.org/docs/apache-airflow/1.10.13/security.html

What this PR does: 
- Airflow login requires valid IDIR
- Any new login with valid IDIR will create new Airflow account (with auto-filled name, username, email)
- Default permission is nothing (called 'Public' role), an admin from Data Foundations has to grant further access 