### PR TITLE
Updated DIP report transformation image tag to main

### DIFF
--- a/dags/bcts_transformations.py
+++ b/dags/bcts_transformations.py
@@ -237,7 +237,7 @@ with DAG(
     
     bcts_timber_inventory_development_in_progress_report_transformation = KubernetesPodOperator(
             task_id="bcts_timber_inventory_development_in_progress_report_transformation",
-            image="ghcr.io/bcgov/nr-dap-ods-bctstransformations:SD-147662-BCTS-DEVELOPMENT-IN-PROGRESS-REPORT",
+            image="ghcr.io/bcgov/nr-dap-ods-bctstransformations:main",
             cmds=["python3", "./bcts_timber_inventory_development_in_progress_transformation.py"],
             image_pull_policy="Always",
             in_cluster=True,


### PR DESCRIPTION
- Updated BCTS DIP report transformation image tag to main. Currently pointing to a branch tag. 